### PR TITLE
CircleCI setup for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,12 +89,21 @@ jobs:
           name: Publish Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASSWORD" | docker login -u outintech --password-stdin
-            IMAGE_TAGE=${CIRCLE_TAG/v/''}
+            IMAGE_TAG=${CIRCLE_TAG/v/''}
             docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
             docker push $IMAGE_NAME:latest
             docker push $IMAGE_NAME:$IMAGE_TAG
-  # deploy:
-
+  deploy:
+    executor: docker-ruby
+      environment:
+        IMAGE_NAME: outintech/nbjc-app
+    steps:
+      - checkout
+      - run:
+          name: Run deploy script
+          command: |
+            DEPLOY_TAG=${CIRCLE_TAG/v/''}
+            bundle exec rake docker:deploy
 
 # Workflows to orchestrate jobs declared above
 workflows:
@@ -122,10 +131,10 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      # - deploy:
-      #     require:
-      #       - publish-image
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
+      - deploy:
+          require:
+            - publish-image
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,10 +105,6 @@ workflows:
       - test:
           requires: # test requires build to pass before running
             - build
-          filters:
-            branches:
-              only:
-                - main
       - build-image: # building a new docker image depends on build and tests passing
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
   deploy:
     executor: docker-ruby
     environment:
-      IMAGE_NAME: outintech/nbjc-app
+      IMAGE_NAME: nbjc-app
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,24 @@ version: 2.1
 orbs: # give us access to specific commands https://circleci.com/docs/2.0/using-orbs/
   ruby: circleci/ruby@1.1.2 # used to cache and install ruby gems
   node: circleci/node@2
+
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: outintech/nbjc-app
+    docker:
+      - image: circleci/buildpacks-deps:stretch
+  docker-ruby:
+    docker:
+      - image: cimg/ruby:2.7.2-node
+        auth:
+          username: outintech
+          password: $DOCKERHUB_PASSWORD
   
 # Jobs to run for this project
 jobs:
   build: # pulls down current code and install dependencies so we can test
-    docker:
-      - image: cimg/ruby:2.7.2-node # using the same version as our Gemfile
-        auth:
-          username: outintech
-          password: $DOCKERHUB_PASSWORD
+    executor: docker-ruby
     steps:
       - checkout # circle ci command to pull down github code https://circleci.com/docs/2.0/configuration-reference/#checkout
       - ruby/install-deps # install gems with bundler
@@ -22,10 +31,7 @@ jobs:
 
   test: # Run tests on new code
     docker:
-      - image: cimg/ruby:2.7.2-node # primary image where step commands run
-        auth:
-          username: outintech
-          password: $DOCKERHUB_PASSWORD
+      executor: docker-ruby
       - image: circleci/postgres:9.5-alpine
         auth:
           username: outintech
@@ -54,19 +60,46 @@ jobs:
           command: bundle exec rails db:schema:load --trace
       # Run rspec in parallel
       - ruby/rspec-test
+  build-image: # build new docker image
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker Image
+          command: |
+            docker build -t $IMAGE_NAME:latest .
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
+  publish-image:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u outintech --password-stdin
+            IMAGE_TAGE=${CIRCLE_TAG/v/''}
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
+            docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$IMAGE_TAG
+  # deploy:
 
-# Build new image using docker
-# 3. Push new image to docker hub
-# sign into docker hub
-# push to docker hub
-# 4. Run pending migrations
-# 5. Rerun docker-compose
-# need to figure out how to run migrations without losing data
 
 # Workflows to orchestrate jobs declared above
 workflows:
   version: 2
-  build_and_test:
+  build_test_publish_deploy:
     jobs:
       - build
       - test:
@@ -76,3 +109,27 @@ workflows:
             branches:
               only:
                 - main
+      - build-image: # building a new docker image depends on build and tests passing
+          require:
+            - build
+            - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish-image:
+          require:
+            - build-image
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      # - deploy:
+      #     require:
+      #       - publish-image
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           cache-key: "yarn.lock"
 
   test: # Run tests on new code
+    executor: docker-ruby
     docker:
-      executor: docker-ruby
       - image: circleci/postgres:9.5-alpine
         auth:
           username: outintech
@@ -110,7 +110,7 @@ workflows:
               only:
                 - main
       - build-image: # building a new docker image depends on build and tests passing
-          require:
+          requires:
             - build
             - test
           filters:
@@ -119,7 +119,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish-image:
-          require:
+          requires:
             - build-image
           filters:
             tags:

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'json'
   gem 'database_cleaner'
   gem 'rspec_junit_formatter'
+  gem 'sshkit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,9 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     msgpack (1.3.3)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.1.0)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -223,6 +226,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sshkit (1.21.2)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -282,6 +288,7 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
+  sshkit
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,8 +22,8 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
   # dev setup
-  user: postgres
-  password: postgres # make sure this corresponds to your local postgres user's password
+  user: nbjc_app
+  password: jS7yPr72NfeZ8HJM6ecHt # make sure this corresponds to your local postgres user's password
   host: <%= ENV.fetch("NBJC_APP_DATABASE_IP") { 'localhost' } %>
   port: 5432
 

--- a/db/seed_data/indicators.csv
+++ b/db/seed_data/indicators.csv
@@ -1,6 +1,14 @@
 name
-ATM
-ASL
-Gender-neutral Restroom
-Black-owned
-POC-owned
+ATM Available
+LGBTQIA+ Friendly
+ASL Spoken
+Wheelchair Ramp On-Site
+Gender-Neutral Restroom
+Black-Owned
+Black-Friendly
+Inclusive
+Multilingual
+Trans-Owned
+Trans-Trained
+Price Conscious
+Accessible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - '3000:3000'
     env_file:
       - .env
+    volumes:
+      - docker-nbjc-api-logs:/var/www/nbjc-app/log
 
 volumes:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - redis:/var/lib/redis/data
       
   api:
-    image: outintech/nbjc-app:latest
+    image: outintech/nbjc-app:$DEPLOY_TAG
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     depends_on:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       
   api:
     image: outintech/nbjc-app:$DEPLOY_TAG
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bundle exec rails s -p 80 -b '0.0.0.0'
     depends_on:
       - redis
     ports:
-      - '3000:3000'
+      - '80:80'
     env_file:
       - .env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
     env_file:
       - .env
     volumes:
-      - docker-nbjc-api-logs:/var/www/nbjc-app/log
+      - api-logs:/var/www/nbjc-app/log
 
 volumes:
   redis:
+  api-logs:
       

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -39,7 +39,7 @@ namespace :docker do
     on server do
       within deploy_path do
         with rails_env: deploy_env, deploy_tag: deploy_tag do
-          execute 'docker-compose', '-f', 'docker-compose.production.yml', 'stop'
+          execute 'docker-compose', '-f', 'docker-compose.yml', 'stop'
         end
       end
     end
@@ -73,7 +73,7 @@ namespace :docker do
     on server do
       within deploy_path do
         with rails_env: deploy_env, deploy_tag: deploy_tag do
-          execute 'docker-compose', '-f', 'docker-compose.yml', 'run', 'app', 'bundle', 'exec', 'rake', 'db:migrate'
+          execute 'docker-compose', '-f', 'docker-compose.yml', 'run', 'api', 'bundle', 'exec', 'rake', 'db:migrate'
         end
       end
     end

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -1,6 +1,7 @@
 # use SSHKit directly
 require 'sshkit'
 require 'sshkit/dsl'
+include SSHKit::DSL
 
 # set the identifier used to used to tag our Docker images
 deploy_tag = ENV['DEPLOY_TAG']
@@ -28,7 +29,7 @@ namespace :docker do
   task :login do
     on server do
       within deploy_path do
-        execute 'docker', 'login', '-e' , ENV['DOCKER_EMAIL'], '-u', ENV['DOCKER_USER'], '-p', "'#{ENV['DOCKERHUB_PASSWORD']}'"
+        execute 'docker', 'login', '-u', ENV['DOCKER_USER'], '-p', "'#{ENV['DOCKERHUB_PASSWORD']}'"
       end
     end
   end

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -1,0 +1,83 @@
+# use SSHKit directly
+require 'sshkit'
+require 'sshkit/dsl'
+
+# set the identifier used to used to tag our Docker images
+deploy_tag = ENV['DEPLOY_TAG']
+
+# set the name of the environment we are deploying to (e.g. staging, production, etc.)
+deploy_env = ENV['DEPLOY_ENV'] || :production
+
+# set the location on the server of where we want files copied to and commands executed from, defaults to /home/USER
+deploy_path = ENV['DEPLOY_PATH'] || "/home/#{ENV['USER']}"
+
+# connect to server
+server = SSHKit::Host.new hostname: ENV['IP'], port: ENV['SERVER_PORT'], user: ENV['USER']
+
+namespace :deploy do
+  desc 'copy to server files needed to run and manage Docker containers'
+  task :configs do
+    on server do
+      upload! File.expand_path('../../docker-compose.yml', __dir__), deploy_path
+    end
+  end
+end
+
+namespace :docker do
+  desc 'logs into Docker Hub for pushing and pulling'
+  task :login do
+    on server do
+      within deploy_path do
+        execute 'docker', 'login', '-e' , ENV['DOCKER_EMAIL'], '-u', ENV['DOCKER_USER'], '-p', "'#{ENV['DOCKERHUB_PASSWORD']}'"
+      end
+    end
+  end
+
+  desc 'stops all Docker containers via Docker Compose'
+  task stop: 'deploy:configs' do
+    on server do
+      within deploy_path do
+        with rails_env: deploy_env, deploy_tag: deploy_tag do
+          execute 'docker-compose', '-f', 'docker-compose.production.yml', 'stop'
+        end
+      end
+    end
+  end
+
+  desc 'starts all Docker containers via Docker Compose'
+  task start: 'deploy:configs' do
+    on server do
+      within deploy_path do
+        with rails_env: deploy_env, deploy_tag: deploy_tag do
+          execute 'docker-compose', '-f', 'docker-compose.yml', 'up', '-d'
+
+          # write the deploy tag to file so we can easily identify the running build
+          execute 'echo', deploy_tag , '>', 'deploy.tag'
+        end
+      end
+    end
+  end
+
+  desc 'pulls images from Docker Hub'
+  task pull: 'docker:login' do
+    on server do
+      within deploy_path do
+          execute 'docker', 'pull', "#{ENV['DOCKER_USER']}/#{ENV['IMAGE_NAME']}:#{deploy_tag}"
+      end
+    end
+  end
+
+  desc 'runs database migrations in application container via Docker Compose'
+  task migrate: 'deploy:configs' do
+    on server do
+      within deploy_path do
+        with rails_env: deploy_env, deploy_tag: deploy_tag do
+          execute 'docker-compose', '-f', 'docker-compose.yml', 'run', 'app', 'bundle', 'exec', 'rake', 'db:migrate'
+        end
+      end
+    end
+  end
+
+  desc 'pulls images, stops old containers, updates the database, and starts new containers'
+  task deploy: %w{docker:pull docker:stop docker:migrate docker:start} # pull images manually to reduce down time
+end

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -80,5 +80,5 @@ namespace :docker do
   end
 
   desc 'pulls images, stops old containers, updates the database, and starts new containers'
-  task deploy: %w{docker:pull docker:stop docker:migrate docker:start} # pull images manually to reduce down time
+  task deploy: %w{docker:pull docker:stop docker:start} # pull images manually to reduce down time
 end


### PR DESCRIPTION
### What
Add jobs for building docker image, updating the image in the outintech DockerHub with a tag and deploying to our server on DigitalOcean. Also adds a rake task deploy script to ssh into the DigitalOcean server, pull down the new image, stop the previous container, start the new container and run migrations with minimum downtime.
### Why
Finish setting up our CI/CD pipeline so that we can focus on coding and have our latest code deployed automatically.