### PR TITLE
dont hit the geocoder api for seeding

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -49,9 +49,14 @@ class Space < ApplicationRecord
       self.photos.create(url: photo_url)
     end
   end
-  
-  after_save :geocode
-  geocoded_by :full_address
+
+  # NOTE: We don't want to hit the geocoder API unless it's production
+  # for example, when seeding the database, we already provide latitude and longitude data
+  # so we don't geocode seeding data
+  if Rails.env.production?
+    after_save :geocode
+    geocoded_by :full_address
+  end
 
   def full_address
     [self.address.address_1, self.address.address_2, self.address.city, self.address.postal_code, self.address.country].compact.join(",")

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,23 @@
+# config/initializers/geocoder.rb
+Geocoder.configure(
+
+  # geocoding service (see below for supported options):
+  # :lookup => :yandex,
+
+  # IP address geocoding service (see below for supported options):
+  # :ip_lookup => :maxmind,
+
+  # to use an API key:
+  # :api_key => "...",
+
+  # geocoding service request timeout, in seconds (default 3):
+  # :timeout => 15,
+
+  # set default units to kilometers:
+  # :units => :km,
+
+  # caching (see below for details):
+  # :cache => Redis.new,
+  # :cache_prefix => "..."
+
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,6 +55,8 @@ if Rails.env.development?
                "photos_attributes": [{ "url": business["image_url"], "cover": true
                                      }],
                "phone": business["phone"],
+               "latitude": business["coordinates"]["latitude"],
+               "longitude": business["coordinates"]["longitude"],
                "hours_of_op": {
                                 "open":[
                                           {


### PR DESCRIPTION
# Description

Geocoder api was being rate limited when seeding the database. This API should not be hit during seeding data or dev mode.

Fixes # (issue)
DEV-104

**Before**
Geocoding would timeout when seeding and return:
`Geocoding API not responding fast enough (use Geocoder.configure(:timeout => ...) to set limit).`

**After**
No message and seeding is fast again.

## Type of change

Please add an 'x' between the brackets for relevant changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> If this is a breaking change for a bug fix, please tag someone from DevOps so they can deploy a new version of the API
- [ ] CI/CD Change (these relate to any changes in the docker-compose or .circleci config file)
- [ ] This change requires a documentation update

## Dependency Changes
* gemfile

# How Has This Been Tested?
running `rails db:seed` after cleaning up database.
