### PR TITLE
Save indicators and languages after creating spaces for seeding 

### DIFF
--- a/app/models/space_language.rb
+++ b/app/models/space_language.rb
@@ -1,4 +1,23 @@
 class SpaceLanguage < ApplicationRecord
   belongs_to :space
   belongs_to :language
+
+  def self.create_languages_for_space(space_languages, space)
+    languages = []
+    (space_languages || []).each do |language|
+      begin
+        db_language = Language.find_by(name: language["name"])
+        space_language = SpaceLanguage.new(language: db_language, space: space)
+        languages << space_language
+      rescue
+      end
+    end
+    languages
+  end
+
+  def self.save_languages(space_languages)
+    (space_languages || []).each do |language|
+      language.save
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -104,21 +104,12 @@ if Rails.env.development?
     end
     Space.create!(spaces)
     Space.find_each do |space| 
-      #Saving indicators after creating spaces prevents seeding duplicate indicators/languages in database.
-      @randomIndicatorsIds = Indicator.all.pluck(:id).sample(Faker::Number.between(from: 1, to: Indicator.all.count - 1))
-      @randomIndicators = Indicator.where(id: @randomIndicatorsIds)
-      @indicatorsForSpace = SpaceIndicator.create_indicators_for_space(@randomIndicators, space)
-      SpaceIndicator.save_indicators(@indicatorsForSpace)
+      @indicators_attributes = Indicator.all.pluck(:id).sample(Faker::Number.between(from: 1, to: Indicator.all.count - 1))
+      SpaceIndicator.save_indicators(SpaceIndicator.create_indicators_for_space(Indicator.where(id: @indicators_attributes), space))
 
-      #Do the same for langugaes I guess
-      #@languageAttributes = Faker::Boolean.boolean ? Language.all.pluck(:id).sample(Faker::Number.between(from: 0, to: Language.all.count - 1)) : []
-      #@randomLanguages = Indicator.where(id: @languageAttributes)
-      #@languagesForSpace = SpaceLanguages.create(@randomLanguages, space)
-      #SpaceLanguages.save_languages(@languagesForSpace)
-    end
-    #puts "Indicators post seeding: #{Indicator.all.pluck(:name).length }"
-    #puts "Languages post seeding: #{Language.all.pluck(:name).length}"
-    #puts "Total number of spaces: #{Space.all.pluck(:name).length}"
+      @language_attributes = Faker::Boolean.boolean ? Language.all.pluck(:id).sample(Faker::Number.between(from: 0, to: Language.all.count - 1)) : []
+      SpaceLanguage.save_languages(SpaceLanguage.create_languages_for_space(Language.where(id: @language_attributes), space))
+    end      
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,10 +47,6 @@ if Rails.env.development?
                                       "country": business["location"]["country"],
                                       "state": business["location"]["state"]
                                      },
-               "languages_attributes": Faker::Boolean.boolean ? Language.all.pluck(:name).sample(
-                                                                  Faker::Number.between(from: 0, to: Language.all.count - 1))
-                                                                  .map{|n| { name: n } } : [],
-               "indicators_attributes": Indicator.all.pluck(:name).sample(Faker::Number.between(from: 1, to: Indicator.all.count - 1)).map{ |n| { name: n } },
                "category_aliases": category_aliases,
                "photos_attributes": [{ "url": business["image_url"], "cover": true
                                      }],
@@ -107,6 +103,22 @@ if Rails.env.development?
       spaces << space
     end
     Space.create!(spaces)
+    Space.find_each do |space| 
+      #Saving indicators after creating spaces prevents seeding duplicate indicators/languages in database.
+      @randomIndicatorsIds = Indicator.all.pluck(:id).sample(Faker::Number.between(from: 1, to: Indicator.all.count - 1))
+      @randomIndicators = Indicator.where(id: @randomIndicatorsIds)
+      @indicatorsForSpace = SpaceIndicator.create_indicators_for_space(@randomIndicators, space)
+      SpaceIndicator.save_indicators(@indicatorsForSpace)
+
+      #Do the same for langugaes I guess
+      #@languageAttributes = Faker::Boolean.boolean ? Language.all.pluck(:id).sample(Faker::Number.between(from: 0, to: Language.all.count - 1)) : []
+      #@randomLanguages = Indicator.where(id: @languageAttributes)
+      #@languagesForSpace = SpaceLanguages.create(@randomLanguages, space)
+      #SpaceLanguages.save_languages(@languagesForSpace)
+    end
+    #puts "Indicators post seeding: #{Indicator.all.pluck(:name).length }"
+    #puts "Languages post seeding: #{Language.all.pluck(:name).length}"
+    #puts "Total number of spaces: #{Space.all.pluck(:name).length}"
   end
 end
 


### PR DESCRIPTION
# Description

Including indicators and languages when creating spaces was causing a new duplicate indicator/language for each many to many relationship between those and spaces.

Fixes # (issue)
DEV-106

**Before**
Tons of duplicate indicators/languages after seeding.

**After**
No duplicate indicators/languages after seeding

## Type of change

Please add an 'x' between the brackets for relevant changes.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> If this is a breaking change for a bug fix, please tag someone from DevOps so they can deploy a new version of the API
- [ ] CI/CD Change (these relate to any changes in the docker-compose or .circleci config file)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Please describe the tests that you added.
Running rake db:reset to reseed the database. 